### PR TITLE
catching EOF

### DIFF
--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -821,7 +821,7 @@ def _authenticate_ssh(org, repo=None):
                           "Enter passphrase for key",
                           "Permission denied",
                           "Are you sure you want to continue connecting"])
-    except pexpect.TIMEOUT:
+    except (pexpect.EOF, pexpect.TIMEOUT):
         return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     python_requires=">= 3.6",
     packages=["lib50"],
     url="https://github.com/cs50/lib50",
-    version="2.0.7",
+    version="2.0.8",
     include_package_data=True
 )


### PR DESCRIPTION
To handle cases such as `ssh` existing with an error in case the SSH daemon is misconfigured for example.