### PR TITLE
add honesty prompt support

### DIFF
--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -69,7 +69,7 @@ def push(tool, slug, config_loader, repo=None, data=None, prompt=lambda question
     with authenticate(remote["org"], repo=repo) as user, prepare(tool, slug, user, included):
 
         # Show any prompt if specified
-        if prompt(honesty, included, excluded):
+        if honesty and prompt(honesty, included, excluded):
             username, commit_hash = upload(slug, user, tool, data)
             format_dict = {"username": username, "slug": slug, "commit_hash": commit_hash}
             message = remote["message"].format(results=remote["results"].format(**format_dict), **format_dict)

--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -68,7 +68,7 @@ def push(tool, slug, config_loader, repo=None, data=None, prompt=lambda question
     # Authenticate the user with GitHub, and prepare the submission
     with authenticate(remote["org"], repo=repo) as user, prepare(tool, slug, user, included):
 
-        # Show any prompt if specified
+        # Show prompt if honesty is not false-y
         if honesty and prompt(honesty, included, excluded):
             username, commit_hash = upload(slug, user, tool, data)
             format_dict = {"username": username, "slug": slug, "commit_hash": commit_hash}

--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -68,8 +68,8 @@ def push(tool, slug, config_loader, repo=None, data=None, prompt=lambda question
     # Authenticate the user with GitHub, and prepare the submission
     with authenticate(remote["org"], repo=repo) as user, prepare(tool, slug, user, included):
 
-        # Show prompt if honesty is not false-y
-        if honesty and prompt(honesty, included, excluded):
+        # Show any prompt if specified
+        if prompt(honesty, included, excluded):
             username, commit_hash = upload(slug, user, tool, data)
             format_dict = {"username": username, "slug": slug, "commit_hash": commit_hash}
             message = remote["message"].format(results=remote["results"].format(**format_dict), **format_dict)

--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -248,9 +248,7 @@ def connect(slug, config_loader):
         }
 
         remote.update(config.get("remote", {}))
-        honesty = config.get("honesty", _("Keeping in mind the course's policy on "
-                                          "academic honesty, are you sure you want to "
-                                          "submit these files?"))
+        honesty = config.get("honesty", True)
 
         # Figure out which files to include and exclude
         included, excluded = files(config.get("files"))

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     python_requires=">= 3.6",
     packages=["lib50"],
     url="https://github.com/cs50/lib50",
-    version="2.0.8",
+    version="3.0.0",
     include_package_data=True
 )

--- a/tests/lib50_tests.py
+++ b/tests/lib50_tests.py
@@ -30,7 +30,7 @@ class TestConnect(unittest.TestCase):
         f = io.StringIO()
         open("hello.py", "w").close()
         with contextlib.redirect_stdout(f):
-            remote, (included, excluded) = lib50.connect("cs50/lib50/tests/bar", self.loader)
+            remote, (honesty, included, excluded) = lib50.connect("cs50/lib50/tests/bar", self.loader)
             self.assertEqual(excluded, set())
 
             self.assertEqual(remote["org"], lib50._api.DEFAULT_PUSH_ORG)
@@ -39,7 +39,7 @@ class TestConnect(unittest.TestCase):
         loader = lib50.config.Loader("submit50")
         loader.scope("files", "exclude", "include", "require")
         with contextlib.redirect_stdout(f):
-            remote, (included, excluded) = lib50.connect("cs50/lib50/tests/bar", loader)
+            remote, (honesty, included, excluded) = lib50.connect("cs50/lib50/tests/bar", loader)
             self.assertEqual(included, {"hello.py"})
 
     def test_missing_problem(self):


### PR DESCRIPTION
Bump major version number since this changes the API for lib50.push (extra argument is passed to prompt). `submit50` still needs to be updated.

Basically, people can now specify 

```
submit50:
    honesty: VALUE
```
where VALUE should either be a string or false-y. This value is passed to the `prompt` function (argument to lib50.push) and defaults to "Keeping in mind this course's policy on academic honesty...". If it is false-y, the user should not be prompted, though it is up to the `prompt` function to implement this behavior.

In `submit50`'s case, when `question` is false,  it should probably still print out all the include/excluded files as normally (no reason not to display this to the student), but should not prompt the student yes/no and just return true.