### PR TITLE
Add many files in batches

### DIFF
--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -490,8 +490,8 @@ def prepare(tool, branch, user, included):
             included_groups = [included[i:i + 32700] for i in range(0, len(included), 32700)]
 
             # Git add all included files
-            for included in included_groups:
-                _run(git(f"add -f {' '.join(shlex.quote(f) for f in included)}"))
+            for group in included_groups:
+                _run(git(f"add -f {' '.join(shlex.quote(f) for f in group)}"))
 
             # Remove gitattributes from included
             if Path(".gitattributes").exists() and ".gitattributes" in included:

--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -487,7 +487,7 @@ def prepare(tool, branch, user, included):
             _run(git("symbolic-ref HEAD {ref}", ref=f"refs/heads/{branch}"))
 
             # Split included files into sublists of OS-friendly lengths
-            included_groups = [included[i:i + n] for i in range(0, len(included), 32700)]
+            included_groups = [included[i:i + 32700] for i in range(0, len(included), 32700)]
 
             # Git add all included files
             for included in included_groups:

--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -486,8 +486,12 @@ def prepare(tool, branch, user, included):
             # Switch to branch without checkout
             _run(git("symbolic-ref HEAD {ref}", ref=f"refs/heads/{branch}"))
 
+            # Split included files into sublists of OS-friendly lengths
+            included_groups = [included[i:i + n] for i in range(0, len(included), 32700)]
+
             # Git add all included files
-            _run(git(f"add -f {' '.join(shlex.quote(f) for f in included)}"))
+            for included in included_groups:
+                _run(git(f"add -f {' '.join(shlex.quote(f) for f in included)}"))
 
             # Remove gitattributes from included
             if Path(".gitattributes").exists() and ".gitattributes" in included:


### PR DESCRIPTION
This is a solution for #40 using the batching suggestion.

**Justification:**
"On a 32-bit Linux, this is ARGMAX/4-1 (32767). This becomes relevant if the average length of arguments is smaller than 4." -- https://www.in-ulm.de/~mascheck/various/argmax/

"On my OSX 10.5 machine (and most other BSD systems) it's 262144" -- https://serverfault.com/questions/69430/what-is-the-maximum-length-of-a-command-line-in-mac-os-x

Thus, this change adds files in batches of 32,700 (nice number, gives plenty of space for other arguments if needed, also pretty large so shouldn't slow the software excessively).