### PR TITLE
accept attrs version >=20, minor version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     license="GPLv3",
     description="This is lib50, CS50's own internal library used in many of its tools.",
-    install_requires=["attrs>=18.1", "pexpect>=4.6,<5", "pyyaml>=3.10,<6", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
+    install_requires=["attrs>=18.1,<21", "pexpect>=4.6,<5", "pyyaml>=3.10,<6", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
     keywords=["lib50"],
     name="lib50",
     python_requires=">= 3.6",

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ setup(
     },
     license="GPLv3",
     description="This is lib50, CS50's own internal library used in many of its tools.",
-    install_requires=["attrs>=18.1,<20", "pexpect>=4.6,<5", "pyyaml>=3.10,<6", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
+    install_requires=["attrs>=18.1", "pexpect>=4.6,<5", "pyyaml>=3.10,<6", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
     keywords=["lib50"],
     name="lib50",
     python_requires=">= 3.6",
     packages=["lib50"],
     url="https://github.com/cs50/lib50",
-    version="2.0.8",
+    version="2.0.9",
     include_package_data=True
 )


### PR DESCRIPTION
This pr removes the version restriction on future attr versions, which we don't do for other tools (check50) either. Pr-ing straight to master because develop is clogged right now.

Students on Discord are experiencing problems with the latest attrs version (20) that seems to have released recently. However, there seem to be no breaking changes: https://www.attrs.org/en/20.1.0/changelog.html. Tested the latest version for both lib50 and check50, and all tests pass and its working as expected. 

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (attrs 20.2.0 (/usr/local/lib/python3.7/site-packages), Requirement.parse('attrs<20,>=18.1'), {'lib50'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/check50", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3250, in <module>
    @_call_aside
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (attrs 20.2.0 (/usr/local/lib/python3.7/site-packages), Requirement.parse('attrs<20,>=18.1'), {'lib50'})
```