### PR TITLE
Read credentials from env vars if possible

### DIFF
--- a/lib50/authentication.py
+++ b/lib50/authentication.py
@@ -189,43 +189,46 @@ def _authenticate_https(org, repo=None):
     api.Git.cache = f"-c credential.helper= -c credential.helper='cache --socket {_CREDENTIAL_SOCKET}'"
     git = api.Git().set(api.Git.cache)
 
-    # Get credentials from cache if possible
-    with api.spawn(git("credential fill"), quiet=True) as child:
-        child.sendline("protocol=https")
-        child.sendline("host=github.com")
-        child.sendline("")
-        i = child.expect([
-            "Username for '.+'",
-            "Password for '.+'",
-            "username=([^\r]+)\r\npassword=([^\r]+)\r\n"
-        ])
-        if i == 2:
-            username, password = child.match.groups()
-        else:
-            username = password = None
-            child.close()
-            child.exitstatus = 0
+    # Get username/PAT from environment variables if possible
+    username = os.environ.get("CS50_GH_USER")
+    password = os.environ.get("CS50_GH_PAT")
 
-    # If password is not in cache
-    if password is None:
+    # Otherwise, get credentials from cache if possible
+    if username is None or password is None:
+        with api.spawn(git("credential fill"), quiet=True) as child:
+            child.sendline("protocol=https")
+            child.sendline("host=github.com")
+            child.sendline("")
+            i = child.expect([
+                "Username for '.+'",
+                "Password for '.+'",
+                "username=([^\r]+)\r\npassword=([^\r]+)\r\n"
+            ])
+            if i == 2:
+                cached_username, cached_password = child.match.groups()
 
-        # Get PAT from CS50PAT environment variable if it exists
-        username = os.environ.get("CS50_GH_USER")
-        password = os.environ.get("CS50_GH_PAT")
+                # if cached credentials differ from existing env variables, don't use cache
+                same_username = username is None or username == cached_username
+                same_password = password is None or password == cached_password
+                if same_username and same_password:
+                    username, password = cached_username, cached_password
+            else:
+                child.close()
+                child.exitstatus = 0
 
-        # Prompt for username
-        if username is None:
-            # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
-            _show_gh_changes_warning()
-            
-            username = _prompt_username(_("Enter username for GitHub: "))
+    # Prompt for username if not in env vars or cache
+    if username is None:
+        # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
+        _show_gh_changes_warning()
         
-        # Prompt for PAT
-        if password is None:
-            # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
-            _show_gh_changes_warning()
+        username = _prompt_username(_("Enter username for GitHub: "))
 
-            password = _prompt_password(_("Enter personal access token for GitHub: "))
+    # Prompt for PAT if not in env vars or cache
+    if password is None:
+        # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
+        _show_gh_changes_warning()
+
+        password = _prompt_password(_("Enter personal access token for GitHub: "))
 
     try:
         # Credentials are correct, best cache them

--- a/lib50/authentication.py
+++ b/lib50/authentication.py
@@ -1,6 +1,7 @@
 import attr
 import contextlib
 import enum
+import os
 import pexpect
 import sys
 import termcolor
@@ -205,14 +206,26 @@ def _authenticate_https(org, repo=None):
             child.close()
             child.exitstatus = 0
 
-    # If password is not in cache, prompt
+    # If password is not in cache
     if password is None:
 
-        # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
-        _show_gh_changes_warning()
+        # Get PAT from CS50PAT environment variable if it exists
+        username = os.environ.get("CS50_GH_USER")
+        password = os.environ.get("CS50_GH_PAT")
 
-        username = _prompt_username(_("Enter username for GitHub: "))
-        password = _prompt_password(_("Enter personal access token for GitHub: "))
+        # Prompt for username
+        if username is None:
+            # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
+            _show_gh_changes_warning()
+            
+            username = _prompt_username(_("Enter username for GitHub: "))
+        
+        # Prompt for PAT
+        if password is None:
+            # Show a quick reminder to check https://cs50.ly/github if not immediately authenticated
+            _show_gh_changes_warning()
+
+            password = _prompt_password(_("Enter personal access token for GitHub: "))
 
     try:
         # Credentials are correct, best cache them

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
     python_requires=">= 3.6",
     packages=["lib50"],
     url="https://github.com/cs50/lib50",
-    version="3.0.2",
+    version="3.0.3",
     include_package_data=True
 )


### PR DESCRIPTION
lib50 will now read from `CS50_GH_USER` and `CS50_GH_PAT` during the https authentication flow. That means authentication now works as follows:

- Try ssh
- Try https
     - Try to get username and/or PAT from env vars
     - If still needed, try the credential cache. Iff env vars are not set or they match what's in the cache.
     - Fallback on user prompts

This way lib50 will only prompt if absolutely needed. Setting just one env var will have lib50 either grab the missing value from the credential cache, or prompt for missing value.