### PR TITLE
Allow pyyaml 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="GPLv3",
     description="This is lib50, CS50's own internal library used in many of its tools.",
     long_description="This is lib50, CS50's own internal library used in many of its tools.",
-    install_requires=["attrs>=18.1,<21", "pexpect>=4.6,<5", "pyyaml>=3.10,<6", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
+    install_requires=["attrs>=18.1,<21", "pexpect>=4.6,<5", "pyyaml>=3.10,<7", "requests>=2.13,<3", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
     extras_require = {
         "develop": ["sphinx", "sphinx-autobuild", "sphinx_rtd_theme"]
     },


### PR DESCRIPTION
With pyyaml 5.x, installation fails with `AttributeError: cython_sources`.