### PR TITLE
Fix need for rust/cargo when installing, allow jellyfish 1.1.3 with prebuilt wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="GPLv3",
     description="This is lib50, CS50's own internal library used in many of its tools.",
     long_description="This is lib50, CS50's own internal library used in many of its tools.",
-    install_requires=["attrs>=18.1,<21", "packaging", "pexpect>=4.6,<5", "pyyaml<7", "requests>=2.13,<3", "setuptools", "termcolor>=1.1,<2", "jellyfish>=0.7,<1", "cryptography>=2.7"],
+    install_requires=["attrs>=18.1,<21", "packaging", "pexpect>=4.6,<5", "pyyaml<7", "requests>=2.13,<3", "setuptools", "termcolor>=1.1,<2", "jellyfish>=0.7,<2", "cryptography>=2.7"],
     extras_require = {
         "develop": ["sphinx", "sphinx-autobuild", "sphinx_rtd_theme"]
     },


### PR DESCRIPTION
As noted in https://github.com/cs50/submit50/issues/364, `pip3 install submit50` or installing anything using `lib50` gives an error requiring rust/cargo to be installed.

This is because `setup.py` enforces jellyfish versions `jellyfish>=0.7,<1`, which defaults to `jellyfish 0.11.3`. There are no prebuilt wheels for for `jellyfish 0.11.3`, so pip says you need to get rust/cargo to build `jellyfish`.

The fix allows versions `jellyfish>=0.7,<2` (currently defaults to 1.1.3) [which has prebuilt macos wheels](https://pypi.org/project/jellyfish/#files), and does not change jaro_wrinkler()

Allowing more recent versions of jellyfish doesn't break anything and makes `pip3 install submit50` far more straightforward for students using submit50 locally.

