### PR TITLE
Remove 3 second timeout for _get_branches spawn call

### DIFF
--- a/lib50/_api.py
+++ b/lib50/_api.py
@@ -798,7 +798,7 @@ class Slug:
         else:
             cmd = f"git ls-remote --heads {self.origin}"
             try:
-                with spawn(cmd, timeout=3) as child:
+                with spawn(cmd) as child:
                     output = child.read().strip().split("\r\n")
             except pexpect.TIMEOUT:
                 if "Username for" in child.buffer:


### PR DESCRIPTION
This addresses the issue #82 

###### Description
Removes the timeout passed to the spawn so as to default to 30 seconds