### PR TITLE
Rm attr

### DIFF
--- a/lib50/authentication.py
+++ b/lib50/authentication.py
@@ -1,5 +1,5 @@
-import attr
 import contextlib
+import dataclasses
 import enum
 import os
 import pexpect
@@ -20,16 +20,18 @@ __all__ = ["User", "authenticate", "logout"]
 _CREDENTIAL_SOCKET = Path("~/.git-credential-cache/lib50").expanduser()
 
 
-@attr.s(slots=True)
+@dataclasses.dataclass(slots=True)
 class User:
     """An authenticated GitHub user that has write access to org/repo."""
-    name = attr.ib()
-    repo = attr.ib()
-    org = attr.ib()
-    passphrase = attr.ib(default=str)
-    email = attr.ib(default=attr.Factory(lambda self: f"{self.name}@users.noreply.github.com",
-                                         takes_self=True),
-                    init=False)
+    name: str
+    repo: str
+    org: str
+    passphrase: str = ""
+    email: str = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self.email = f"{self.name}@users.noreply.github.com"
+
 
 @contextlib.contextmanager
 def authenticate(org, repo=None, auth_method=None):

--- a/lib50/authentication.py
+++ b/lib50/authentication.py
@@ -20,7 +20,7 @@ __all__ = ["User", "authenticate", "logout"]
 _CREDENTIAL_SOCKET = Path("~/.git-credential-cache/lib50").expanduser()
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass
 class User:
     """An authenticated GitHub user that has write access to org/repo."""
     name: str

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="GPLv3",
     description="This is lib50, CS50's own internal library used in many of its tools.",
     long_description="This is lib50, CS50's own internal library used in many of its tools.",
-    install_requires=["attrs>=18.1,<21", "packaging", "pexpect>=4.6,<5", "pyyaml<7", "requests>=2.13,<3", "setuptools", "termcolor>=1.1,<2", "jellyfish>=1,<2", "cryptography>=2.7"],
+    install_requires=["packaging", "pexpect>=4.6,<5", "pyyaml<7", "requests>=2.13,<3", "setuptools", "termcolor>=1.1,<2", "jellyfish>=1,<2", "cryptography>=2.7"],
     extras_require = {
         "develop": ["sphinx", "sphinx-autobuild", "sphinx_rtd_theme"]
     },


### PR DESCRIPTION
Per @cmlsharp's comment in https://github.com/cs50/check50/pull/368, Python 3.7 brought with it dataclasses that can directly replace `attrs`. This pr replaces the only use of `attrs` in `lib50` with dataclasses and removes `attrs` as a dependency. `lib50` already requires python>=3.8, so no change needed there.

`slots` can be set through dataclasses too, but requires python>=3.10 (see https://docs.python.org/3/library/dataclasses.html#module-contents). Functionally this is not needed for `lib50`.